### PR TITLE
Reverse names for S3 sort

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.154.0",
-    "@thi.ng/base-n": "^2.3.12",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.154.0",
+    "@thi.ng/base-n": "^2.3.12",
     "uuid": "^8.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Use base 36 filenames, reverse names for S3 sort

Fyi, this does not seek to fix likely pagination problems with delete